### PR TITLE
refactor: clean up codecompanion config

### DIFF
--- a/lua/plugins/codecompanion.lua
+++ b/lua/plugins/codecompanion.lua
@@ -11,80 +11,25 @@ return {
       },
       strategies = {
         chat = {
-          adapter = "copilot",
           roles = {
             llm = "  Copilot ",
             user = "  D7OM ",
           },
-        },
-      },
-      inline = {
-        adapter = "copilot",
-      },
-      agent = {
-        adapter = "copilot",
-      },
-      keymaps = {
-        close = {
-          modes = {
-            n = "<C-c>",
-            i = "q",
+          keymaps = {
+            close = {
+              modes = {
+                n = "<C-c>",
+                i = "q",
+              },
+              index = 3,
+              callback = "keymaps.close",
+              description = "Close Chat",
+            },
           },
-          index = 3,
-          callback = "keymaps.close",
-          description = "Close Chat",
         },
       },
-
       -- PROMPTS ------------------------------------------------------
       prompt_library = {
-        ["Fix code"] = {
-          strategy = "chat",
-          description = "Fix the selected code",
-          opts = {
-            default_prompt = true,
-            short_name = "fix",
-            modes = { "v" },
-            slash_cmd = "fix",
-            auto_submit = true,
-            user_prompt = false,
-            stop_context_insertion = true,
-          },
-          prompts = {
-            {
-              role = "system",
-              content = [[When asked to fix code, follow these steps:
-
-    1. **Identify the Issues**: Carefully read the provided code and identify any potential issues or improvements.
-    2. **Plan the Fix**: Describe the plan for fixing the code in pseudocode, detailing each step.
-    3. **Implement the Fix**: Write the corrected code in a single code block.
-    4. **Explain the Fix**: Briefly explain what changes were made and why.
-
-    Ensure the fixed code:
-
-    - Includes necessary imports.
-    - Handles potential errors.
-    - Follows best practices for readability and maintainability.
-    - Is formatted correctly.
-
-    Use Markdown formatting and include the programming language name at the start of the code block.]],
-              opts = {
-                visible = false,
-              },
-            },
-            {
-              role = "user",
-              content = function(context)
-                local code = require("codecompanion.helpers.actions").get_code(context.start_line, context.end_line)
-
-                return "Please fix the selected code:\n\n```" .. context.filetype .. "\n" .. code .. "\n```\n\n"
-              end,
-              opts = {
-                contains_code = true,
-              },
-            },
-          },
-        },
         ["Fix LSP Diagnostics"] = {
           strategy = "chat",
           description = "Fix the LSP diagnostics",
@@ -92,7 +37,7 @@ return {
             default_prompt = true,
             short_name = "lsp-fix",
             modes = { "n", "v" },
-            slash_cmd = "buffer",
+            slash_cmd = "lsp-fix",
             auto_submit = true,
             user_prompt = false,
             stop_context_insertion = true,


### PR DESCRIPTION
1. Copilot is the default adapter by default so you don't need to specify this (you might want to think about changing the default model, however)
2. Removed the Fix prompt from the prompt library as you're just copying the default one from CodeCompanion. When you do this, you prevent any future config changes from being propagated into your setup
3. Your keymaps were organized incorrectly
4. The agent strategy no longer exists